### PR TITLE
Add support for rust rover

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Supports
 - PyCharm (toolbox)
 - Rider (toolbox)
 - RubyMine (toolbox)
+- RustRover (toolbox)
 - WebStorm (toolbox)
 
 Under the hood this is a small systemd user service which implements the [search provider][1] DBus API and exposes recent projects from Jetbrains IDEs.

--- a/providers/de.swsnr.searchprovider.jetbrains.toolbox.rustrover.ini
+++ b/providers/de.swsnr.searchprovider.jetbrains.toolbox.rustrover.ini
@@ -1,0 +1,5 @@
+[Shell Search Provider]
+DesktopId=jetbrains-rustrover.desktop
+BusName=de.swsnr.searchprovider.Jetbrains
+ObjectPath=/de/swsnr/searchprovider/jetbrains/toolbox/rustrover
+Version=2

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,6 +320,16 @@ const PROVIDERS: &[ProviderDefinition] = &[
         },
     },
     ProviderDefinition {
+        label: "RustRover (toolbox)",
+        desktop_id: "jetbrains-rustrover.desktop",
+        relative_obj_path: "toolbox/rustrover",
+        config: ConfigLocation {
+            vendor_dir: "JetBrains",
+            config_prefix: "RustRover",
+            projects_filename: "recentProjects.xml",
+        },
+    },
+    ProviderDefinition {
         label: "Android Studio (toolbox)",
         desktop_id: "jetbrains-studio.desktop",
         relative_obj_path: "toolbox/studio",


### PR DESCRIPTION
Adds support for the new rustrover ide. Although the ide is in preview at this point, it should not make any difference when jetbrains releases it unless they change the name.