### PR TITLE
[FIX] Change uninstall target to prevent deleting all files in $BINDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install:
 .PHONY: uninstall
 uninstall:
 	rm -f $(addprefix $(DESTDIR)$(SEARCH_PROVIDERS_DIR)/,$(notdir $(SEARCH_PROVIDERS)))
-	rm -rf $(DESTDIR)$(BINDIR)/
+	rm -rf $(DESTDIR)$(BINDIR)/gnome-search-providers-jetbrains
 	rm -f $(DESTDIR)$(USERUNITDIR)/gnome-search-providers-jetbrains.service
 	rm -f $(DESTDIR)$(DBUS_SERVICES_DIR)/de.swsnr.searchprovider.Jetbrains.service
 


### PR DESCRIPTION
This is a small fix to prevent unintentionally deleting all files in the `/usr/local/bin` directory when uninstalling a build that was installed using a Makefile.